### PR TITLE
Merge worker dynos together.

### DIFF
--- a/Dockerfile.services
+++ b/Dockerfile.services
@@ -1,8 +1,0 @@
-FROM redash/redash:10.1.0.b50633
-
-ENV WORKERS_COUNT=1
-ENV QUEUES="periodic emails default"
-
-WORKDIR /app
-
-CMD exec supervisord -c worker.conf

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -1,7 +1,7 @@
 FROM redash/redash:10.1.0.b50633
 
 ENV WORKERS_COUNT=${WORKERS_COUNT:-1}
-ENV QUEUES="queries scheduled_queries schemas"
+ENV QUEUES="queries scheduled_queries schemas periodic emails default"
 
 WORKDIR /app
 

--- a/heroku.yml
+++ b/heroku.yml
@@ -3,4 +3,3 @@ build:
     web: Dockerfile.web
     worker: Dockerfile.worker
     scheduler: Dockerfile.scheduler
-    services: Dockerfile.services


### PR DESCRIPTION
Save dyno units by merging in the two separate dynos into one. Our queue processing patterns indicate this will have no impact on query execution or other related items.