### PR TITLE
[SEC-856] added host header and x forwarded host stripping for non whitelisted domains

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,7 +1,8 @@
 FROM redash/redash:10.1.0.b50633
 RUN pip install snowflake-connector-python cryptography
 COPY redash/query_runner/snowflake_keypair_env.py /app/redash/query_runner/
+COPY wsgi_heroku.py /app/wsgi_heroku.py
 RUN cp /app/client/dist/images/db-logos/snowflake.png \
         /app/client/dist/images/db-logos/snowflake_keypair_env.png || true
 WORKDIR /app
-CMD /usr/local/bin/gunicorn -b 0.0.0.0:$PORT --name redash -w${REDASH_WEB_WORKERS:-1} redash.wsgi:app
+CMD /usr/local/bin/gunicorn -b 0.0.0.0:$PORT --name redash -w${REDASH_WEB_WORKERS:-1} wsgi_heroku:app

--- a/README.md
+++ b/README.md
@@ -54,19 +54,22 @@ redirect URLs.
 
 On each request it:
 
-1. Strips `X-Forwarded-Host` from the WSGI environ (Heroku already sets the
-   correct hostname in `Host`)
-2. Rejects requests whose `Host` header is not in the allowlist (when configured)
+1. Strips `X-Forwarded-Host` when it fails the same allowlist check used for
+   `Host` (`REDASH_HOST` + `REDASH_ALLOWED_HOSTS`). Allowlisted values are kept.
+2. Rejects requests whose `Host` header fails that same check (when
+   `REDASH_VALIDATE_HOST` is enabled)
 3. Sets Flask `SERVER_NAME` and `PREFERRED_URL_SCHEME` from `REDASH_HOST`
+
+If `REDASH_HOST` is unset, the allowlist is empty and both checks are skipped.
 
 Environment variables read by `wsgi_heroku.py`:
 
 | Variable                        | Default   | Description                                                                                                                                                    |
 | ------------------------------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `REDASH_HOST`                   | _(unset)_ | Canonical URL for the app (e.g. `https://redash.example.com`). Used for the host allowlist and Flask `SERVER_NAME`. Required for host validation to be active. |
-| `REDASH_ALLOWED_HOSTS`          | _(unset)_ | Comma-separated extra hostnames allowed in the `Host` header (e.g. a Heroku default domain during migration).                                                  |
-| `REDASH_STRIP_X_FORWARDED_HOST` | `true`    | Remove `X-Forwarded-Host` before the request reaches Redash.                                                                                                   |
-| `REDASH_VALIDATE_HOST`          | `true`    | Return `400` when `Host` does not match `REDASH_HOST` or `REDASH_ALLOWED_HOSTS`. Skipped if no allowlist is configured.                                        |
+| `REDASH_ALLOWED_HOSTS`          | _(unset)_ | Comma-separated extra hostnames allowed in `Host` and `X-Forwarded-Host` (e.g. a Heroku default domain during migration).                                      |
+| `REDASH_STRIP_X_FORWARDED_HOST` | `true`    | Strip `X-Forwarded-Host` when it fails the same allowlist check as `Host`.                                                                                     |
+| `REDASH_VALIDATE_HOST`          | `true`    | Return `400` when `Host` fails the allowlist check. Skipped if `REDASH_HOST` is unset.                                                                         |
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -54,22 +54,21 @@ redirect URLs.
 
 On each request it:
 
-1. Strips `X-Forwarded-Host` when it fails the same allowlist check used for
-   `Host` (`REDASH_HOST` + `REDASH_ALLOWED_HOSTS`). Allowlisted values are kept.
-2. Rejects requests whose `Host` header fails that same check (when
-   `REDASH_VALIDATE_HOST` is enabled)
+1. Strips `X-Forwarded-Host` when it fails the allowlist check (`REDASH_HOST` +
+   `REDASH_ALLOWED_HOSTS`). Allowlisted values are kept.
+2. Rewrites `Host` to `REDASH_HOST` on every request when `REDASH_HOST` is set
 3. Sets Flask `SERVER_NAME` and `PREFERRED_URL_SCHEME` from `REDASH_HOST`
 
-If `REDASH_HOST` is unset, the allowlist is empty and both checks are skipped.
+If `REDASH_HOST` is unset, the allowlist is empty, `Host` is not rewritten, and
+the `X-Forwarded-Host` strip is skipped.
 
 Environment variables read by `wsgi_heroku.py`:
 
 | Variable                        | Default   | Description                                                                                                                                                    |
 | ------------------------------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `REDASH_HOST`                   | _(unset)_ | Canonical URL for the app (e.g. `https://redash.example.com`). Used for the host allowlist and Flask `SERVER_NAME`. Required for host validation to be active. |
-| `REDASH_ALLOWED_HOSTS`          | _(unset)_ | Comma-separated extra hostnames allowed in `Host` and `X-Forwarded-Host` (e.g. a Heroku default domain during migration).                                      |
-| `REDASH_STRIP_X_FORWARDED_HOST` | `true`    | Strip `X-Forwarded-Host` when it fails the same allowlist check as `Host`.                                                                                     |
-| `REDASH_VALIDATE_HOST`          | `true`    | Return `400` when `Host` fails the allowlist check. Skipped if `REDASH_HOST` is unset.                                                                         |
+| `REDASH_HOST`                   | _(unset)_ | Canonical URL for the app (e.g. `https://redash.example.com`). Used for Flask `SERVER_NAME` and to rewrite `Host` on every request.                          |
+| `REDASH_ALLOWED_HOSTS`          | _(unset)_ | Comma-separated extra hostnames allowed in `X-Forwarded-Host` (e.g. a Heroku default domain during migration).                                                 |
+| `REDASH_STRIP_X_FORWARDED_HOST` | `true`    | Strip `X-Forwarded-Host` when it fails the allowlist check.                                                                                                    |
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,36 @@ heroku config:set REDASH_MAIL_DEFAULT_SENDER=YOUR_MAIL_ADDRESS
 
 See also https://redash.io/help/open-source/setup#-setup
 
+### `wsgi_heroku.py`
+
+The web dyno loads `wsgi_heroku.py` instead of Redash's default `redash.wsgi`.
+It wraps the normal Flask app and runs before Redash's `ProxyFix` middleware,
+which otherwise trusts `X-Forwarded-Host` and can reflect a spoofed hostname in
+redirect URLs.
+
+On each request it:
+
+1. Strips `X-Forwarded-Host` from the WSGI environ (Heroku already sets the
+   correct hostname in `Host`)
+2. Rejects requests whose `Host` header is not in the allowlist (when configured)
+3. Sets Flask `SERVER_NAME` and `PREFERRED_URL_SCHEME` from `REDASH_HOST`
+
+Environment variables read by `wsgi_heroku.py`:
+
+| Variable                        | Default   | Description                                                                                                                                                    |
+| ------------------------------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `REDASH_HOST`                   | _(unset)_ | Canonical URL for the app (e.g. `https://redash.example.com`). Used for the host allowlist and Flask `SERVER_NAME`. Required for host validation to be active. |
+| `REDASH_ALLOWED_HOSTS`          | _(unset)_ | Comma-separated extra hostnames allowed in the `Host` header (e.g. a Heroku default domain during migration).                                                  |
+| `REDASH_STRIP_X_FORWARDED_HOST` | `true`    | Remove `X-Forwarded-Host` before the request reaches Redash.                                                                                                   |
+| `REDASH_VALIDATE_HOST`          | `true`    | Return `400` when `Host` does not match `REDASH_HOST` or `REDASH_ALLOWED_HOSTS`. Skipped if no allowlist is configured.                                        |
+
+Example:
+
+```sh
+heroku config:set REDASH_HOST=https://redash.example.com
+heroku config:set REDASH_ALLOWED_HOSTS=your-app.herokuapp.com
+```
+
 ### Release container
 
 ```sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@
 # Some other recommendations:
 # 1. To persist Postgres data, assign it a volume host location.
 # 2. Split the worker service to adhoc workers and scheduled queries workers.
-version: '2'
+version: "2"
 services:
   server:
     build:

--- a/wsgi_heroku.py
+++ b/wsgi_heroku.py
@@ -5,9 +5,9 @@ Redash wraps the app with Werkzeug ProxyFix (x_host=1), which trusts
 X-Forwarded-Host for redirect URL generation. Clients can supply that header
 directly; Heroku forwards it even though the router does not trust it.
 
-On Heroku the authoritative public hostname is already in the Host header, so
-we strip X-Forwarded-Host before the request reaches Redash and optionally pin
-Flask's SERVER_NAME to REDASH_HOST.
+On Heroku the authoritative public hostname is already in the Host header.
+Non-allowlisted X-Forwarded-Host values are stripped before Redash's ProxyFix
+runs; allowlisted values are passed through for trusted proxy setups.
 """
 import os
 from urllib.parse import urlparse
@@ -38,16 +38,16 @@ def _allowed_hosts():
     return hosts
 
 
-def _host_is_allowed(host_header, allowed_hosts):
+def _host_matches_allowlist(host_value, allowed_hosts):
     if not allowed_hosts:
         return True
-    if not host_header:
+    if not host_value:
         return False
 
-    host_header = host_header.lower()
-    hostname = host_header.split(":")[0]
+    host_value = host_value.lower()
+    hostname = host_value.split(":")[0]
     for allowed in allowed_hosts:
-        if host_header == allowed:
+        if host_value == allowed:
             return True
         if hostname == allowed.split(":")[0]:
             return True
@@ -77,14 +77,15 @@ allowed_hosts = _allowed_hosts()
 
 def app(environ, start_response):
     if STRIP_X_FORWARDED_HOST:
-        environ.pop("HTTP_X_FORWARDED_HOST", None)
+        forwarded_host = environ.get("HTTP_X_FORWARDED_HOST")
+        if forwarded_host and not _host_matches_allowlist(forwarded_host, allowed_hosts):
+            environ.pop("HTTP_X_FORWARDED_HOST", None)
 
-    if VALIDATE_HOST and allowed_hosts:
-        if not _host_is_allowed(environ.get("HTTP_HOST", ""), allowed_hosts):
-            start_response(
-                "400 Bad Request",
-                [("Content-Type", "text/plain; charset=utf-8")],
-            )
-            return [b"Invalid Host header"]
+    if VALIDATE_HOST and not _host_matches_allowlist(environ.get("HTTP_HOST", ""), allowed_hosts):
+        start_response(
+            "400 Bad Request",
+            [("Content-Type", "text/plain; charset=utf-8")],
+        )
+        return [b"Invalid Host header"]
 
     return flask_app(environ, start_response)

--- a/wsgi_heroku.py
+++ b/wsgi_heroku.py
@@ -82,10 +82,6 @@ def app(environ, start_response):
             environ.pop("HTTP_X_FORWARDED_HOST", None)
 
     if VALIDATE_HOST and not _host_matches_allowlist(environ.get("HTTP_HOST", ""), allowed_hosts):
-        start_response(
-            "400 Bad Request",
-            [("Content-Type", "text/plain; charset=utf-8")],
-        )
-        return [b"Invalid Host header"]
+        environ["HTTP_HOST"] = redash_host
 
     return flask_app(environ, start_response)

--- a/wsgi_heroku.py
+++ b/wsgi_heroku.py
@@ -1,0 +1,90 @@
+"""
+WSGI entrypoint for Redash on Heroku.
+
+Redash wraps the app with Werkzeug ProxyFix (x_host=1), which trusts
+X-Forwarded-Host for redirect URL generation. Clients can supply that header
+directly; Heroku forwards it even though the router does not trust it.
+
+On Heroku the authoritative public hostname is already in the Host header, so
+we strip X-Forwarded-Host before the request reaches Redash and optionally pin
+Flask's SERVER_NAME to REDASH_HOST.
+"""
+import os
+from urllib.parse import urlparse
+
+from redash import create_app
+
+
+def _parse_redash_host(value):
+    if not value:
+        return None, None
+    if "://" not in value:
+        value = f"https://{value}"
+    parsed = urlparse(value)
+    host = (parsed.netloc or parsed.path).lower()
+    scheme = parsed.scheme or "https"
+    return host, scheme
+
+
+def _allowed_hosts():
+    hosts = set()
+    primary, _ = _parse_redash_host(os.environ.get("REDASH_HOST", ""))
+    if primary:
+        hosts.add(primary)
+    for entry in os.environ.get("REDASH_ALLOWED_HOSTS", "").split(","):
+        entry = entry.strip().lower()
+        if entry:
+            hosts.add(entry)
+    return hosts
+
+
+def _host_is_allowed(host_header, allowed_hosts):
+    if not allowed_hosts:
+        return True
+    if not host_header:
+        return False
+
+    host_header = host_header.lower()
+    hostname = host_header.split(":")[0]
+    for allowed in allowed_hosts:
+        if host_header == allowed:
+            return True
+        if hostname == allowed.split(":")[0]:
+            return True
+    return False
+
+
+def _as_bool(name, default):
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() in ("1", "true", "yes", "on")
+
+
+STRIP_X_FORWARDED_HOST = _as_bool("REDASH_STRIP_X_FORWARDED_HOST", True)
+VALIDATE_HOST = _as_bool("REDASH_VALIDATE_HOST", True)
+
+flask_app = create_app()
+
+redash_host, redash_scheme = _parse_redash_host(os.environ.get("REDASH_HOST", ""))
+if redash_host:
+    flask_app.config["SERVER_NAME"] = redash_host
+    if redash_scheme:
+        flask_app.config["PREFERRED_URL_SCHEME"] = redash_scheme
+
+allowed_hosts = _allowed_hosts()
+
+
+def app(environ, start_response):
+    if STRIP_X_FORWARDED_HOST:
+        environ.pop("HTTP_X_FORWARDED_HOST", None)
+
+    if VALIDATE_HOST and allowed_hosts:
+        if not _host_is_allowed(environ.get("HTTP_HOST", ""), allowed_hosts):
+            start_response(
+                "400 Bad Request",
+                [("Content-Type", "text/plain; charset=utf-8")],
+            )
+            return [b"Invalid Host header"]
+
+    return flask_app(environ, start_response)


### PR DESCRIPTION
[SEC]-856 

## Summary ##
redash is vulnerable to header poisoning via the host and x-forwarded-host headers.
add host and x-forwarded-host whitelist to limit valid options for host and x-forwarded-host

## Proof this works ##
Before:
<img width="1663" height="407" alt="Screenshot 2026-06-29 at 2 36 44 PM" src="https://github.com/user-attachments/assets/9efa92bb-15b2-4462-8b58-23c401692199" />

After:
<img width="1664" height="400" alt="Screenshot 2026-06-29 at 2 37 36 PM" src="https://github.com/user-attachments/assets/65f71f5d-ab6e-471e-be69-655f05070354" />
<img width="833" height="914" alt="Screenshot 2026-06-30 at 12 21 48 PM" src="https://github.com/user-attachments/assets/b2e0717f-3b76-4505-9855-c0756ac77df2" />

local ui working:
<img width="2554" height="1374" alt="Screenshot 2026-06-30 at 9 54 12 AM" src="https://github.com/user-attachments/assets/a70f8043-cf4e-4b98-b8b5-d35e77936046" />

